### PR TITLE
fix(generators): replaces incompatible characters in schema with sane defaults

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export { Generator } from './types'
  *
  */
 const sanitizeSchema = (schema: string) =>
-    schema.replace(/\`/g, "\\`")
+    schema.replace(/\`/g, '\\`')
 
 export function generateCode(schema: string, generator: Generator | string): string {
     if (typeof generator === 'string'){

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,19 @@ import { Generator } from './types'
 
 export { Generator } from './types'
 
+/**
+ * The schema contains incompatible characters sometimes, e.g.
+ * data types in comments are emphasized with "`", which represents
+ * template strings in ES2015 and TypeScript. This function
+ * replaces those characters with sane defaults.
+ *
+ * @param schema {String} The serialized schema
+ * @returns {String}
+ *
+ */
+const sanitizeSchema = (schema: string) =>
+    schema.replace(/\`/g, "\\`")
+
 export function generateCode(schema: string, generator: Generator | string): string {
     if (typeof generator === 'string'){
       generator = generators[generator] || require(generator).generator
@@ -14,6 +27,8 @@ export function generateCode(schema: string, generator: Generator | string): str
 ${Object.keys(generators).map(k => `'${k}`).join(', ')}`)
       }
     }
+
+    schema = sanitizeSchema(schema);
 
     const document: DocumentNode = parse(schema, { noLocation: true })
     const ast: GraphQLSchema = buildASTSchema(document)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export { Generator } from './types'
  *
  */
 const sanitizeSchema = (schema: string) =>
-    schema.replace(/\`/g, '\\`')
+    schema.replace(/\`/g, '\'')
 
 export function generateCode(schema: string, generator: Generator | string): string {
     if (typeof generator === 'string'){

--- a/test/features/graphcool-ts.feature
+++ b/test/features/graphcool-ts.feature
@@ -18,7 +18,7 @@ Feature for Graphcool Typescript generator
       import { GraphQLResolveInfo } from 'graphql'
 
       const typeDefs = `
-      # The \`Query\` type
+      # The 'Query' type
       type Query {
         posts: [String]
       }`

--- a/test/features/graphcool-ts.feature
+++ b/test/features/graphcool-ts.feature
@@ -5,6 +5,7 @@ Feature for Graphcool Typescript generator
   Scenario: Scenario name
     Given a schema looking like this:
       """
+      # The `Query` type
       type Query {
         posts: [String]
       }
@@ -17,6 +18,7 @@ Feature for Graphcool Typescript generator
       import { GraphQLResolveInfo } from 'graphql'
 
       const typeDefs = `
+      # The \`Query\` type
       type Query {
         posts: [String]
       }`

--- a/test/test.ts
+++ b/test/test.ts
@@ -2536,6 +2536,10 @@ input LocationWhereUniqueInput {
   id: ID
 }
 
+"""
+The \`Long\` scalar type represents non-fractional signed whole numeric values.
+Long can represent values between -(2^63) and 2^63 - 1.
+"""
 scalar Long
 
 type MessageConnection {


### PR DESCRIPTION
This PR fixes problems with incompatible characters in the SDL. It replaces `backticks` with single quotes at the moment.

## Background
I encountered today that the SDL contains annotated comments from time to time. For example:

```
"""
The `Long` scalar type represents non-fractional signed whole numeric values.
Long can represent values between -(2^63) and 2^63 - 1.
"""
scalar Long
```

This leads to a syntax error in `ES2015` and `TypeScript` because the template string `typedefs` gets terminated by this data type annotation. This PR replaces backticks with single quotes:

```
"""
The 'Long' scalar type represents non-fractional signed whole numeric values.
Long can represent values between -(2^63) and 2^63 - 1.
"""
scalar Long
```
